### PR TITLE
Remove pin to snappy 1.1.8 now that RTTI fix is merged

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "2022.10.31.00" %}  # PEP 386
 {% set jemalloc_enabled = folly_build_ext is not undefined and folly_build_ext == "jemalloc" %}
 ### IMPORTANT: always keep the build number in build_string and in build/number equal!
-{% set build_string = "h{}_1".format(PKG_HASH) %}
+{% set build_string = "h{}_3".format(PKG_HASH) %}
 {% set build_string_ext = "{}_jemalloc".format(build_string) if jemalloc_enabled else build_string  %}
 
 package:
@@ -15,7 +15,7 @@ source:
     - 0001-Use-CMAKE_SYSTEM_PROCESSOR-instead-of-CMAKE_LIBRARY_.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
   string: {{ build_string_ext }}
   ignore_run_exports:
@@ -38,8 +38,7 @@ requirements:
     - libaio  # [linux]
     - libevent
     - libsodium
-    # snappy 1.1.9 breaks linking with folly, see https://github.com/facebook/folly/issues/1606
-    - snappy 1.1.8
+    - snappy
     - bzip2
     - lz4-c
     - openssl
@@ -50,7 +49,7 @@ requirements:
     - boost-cpp
     - jemalloc        # [(not osx) and (folly_build_ext is not undefined and folly_build_ext == "jemalloc")]
     - jemalloc-local  # [osx and (folly_build_ext is not undefined and folly_build_ext == "jemalloc")]
-    - snappy 1.1.8
+    - snappy
 
 test:
   requires:


### PR DESCRIPTION
https://github.com/conda-forge/snappy-feedstock/pull/32

Resolves #71 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
