### PR TITLE
[`2023.08.07.00`] Export strict runtime requirements due to ABI unstability

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -59,11 +59,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,11 +13,15 @@ source:
     - 0001-Use-CMAKE_SYSTEM_PROCESSOR-instead-of-CMAKE_LIBRARY_.patch
 
 build:
-  number: 0
+  number: 1
   string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}{{ build_ext }}
   ignore_run_exports:
     - jemalloc        # [(not osx) and (folly_build_ext is not undefined and folly_build_ext == "jemalloc")]
     - jemalloc-local  # [osx and (folly_build_ext is not undefined and folly_build_ext == "jemalloc")]
+  run_exports:
+    # Since folly is ABI-unstable, the exact same version must be used at compile time and runtime.
+    # See: https://github.com/facebook/folly/#build-notes
+    - {{ pin_subpackage('folly', max_pin='x.x.x.x') }}
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Backport https://github.com/conda-forge/folly-feedstock/pull/129 for folly `2023.08.07.00`.

Branching off from bfed2a6c93e8b9a1ee925476d71e23506cb4333a.

<!--
Please add any other relevant info below:
-->
