### PR TITLE
Explicitly build against libevent 2.1.10 and libevent 2.1.12 (continued)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,72 +8,72 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_fmt10folly_build_extNonelibevent2.1.10:
-        CONFIG: linux_64_fmt10folly_build_extNonelibevent2.1.10
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_fmt10folly_build_extNonelibevent2.1.12:
         CONFIG: linux_64_fmt10folly_build_extNonelibevent2.1.12
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_fmt10folly_build_extjemalloclibevent2.1.10:
-        CONFIG: linux_64_fmt10folly_build_extjemalloclibevent2.1.10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_fmt10folly_build_extjemalloclibevent2.1.12:
         CONFIG: linux_64_fmt10folly_build_extjemalloclibevent2.1.12
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_fmt9folly_build_extNonelibevent2.1.10:
+        CONFIG: linux_64_fmt9folly_build_extNonelibevent2.1.10
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_fmt9folly_build_extNonelibevent2.1.12:
         CONFIG: linux_64_fmt9folly_build_extNonelibevent2.1.12
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_fmt9folly_build_extjemalloclibevent2.1.10:
+        CONFIG: linux_64_fmt9folly_build_extjemalloclibevent2.1.10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_fmt9folly_build_extjemalloclibevent2.1.12:
         CONFIG: linux_64_fmt9folly_build_extjemalloclibevent2.1.12
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_fmt10folly_build_extNonelibevent2.1.10:
-        CONFIG: linux_aarch64_fmt10folly_build_extNonelibevent2.1.10
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_fmt10folly_build_extNonelibevent2.1.12:
         CONFIG: linux_aarch64_fmt10folly_build_extNonelibevent2.1.12
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_fmt10folly_build_extjemalloclibevent2.1.10:
-        CONFIG: linux_aarch64_fmt10folly_build_extjemalloclibevent2.1.10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_fmt10folly_build_extjemalloclibevent2.1.12:
         CONFIG: linux_aarch64_fmt10folly_build_extjemalloclibevent2.1.12
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_fmt9folly_build_extNonelibevent2.1.10:
+        CONFIG: linux_aarch64_fmt9folly_build_extNonelibevent2.1.10
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_fmt9folly_build_extNonelibevent2.1.12:
         CONFIG: linux_aarch64_fmt9folly_build_extNonelibevent2.1.12
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_fmt9folly_build_extjemalloclibevent2.1.10:
+        CONFIG: linux_aarch64_fmt9folly_build_extjemalloclibevent2.1.10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_fmt9folly_build_extjemalloclibevent2.1.12:
         CONFIG: linux_aarch64_fmt9folly_build_extjemalloclibevent2.1.12
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_fmt10folly_build_extNonelibevent2.1.10:
-        CONFIG: linux_ppc64le_fmt10folly_build_extNonelibevent2.1.10
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_fmt10folly_build_extNonelibevent2.1.12:
         CONFIG: linux_ppc64le_fmt10folly_build_extNonelibevent2.1.12
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_fmt10folly_build_extjemalloclibevent2.1.10:
-        CONFIG: linux_ppc64le_fmt10folly_build_extjemalloclibevent2.1.10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_fmt10folly_build_extjemalloclibevent2.1.12:
         CONFIG: linux_ppc64le_fmt10folly_build_extjemalloclibevent2.1.12
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_fmt9folly_build_extNonelibevent2.1.10:
+        CONFIG: linux_ppc64le_fmt9folly_build_extNonelibevent2.1.10
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_fmt9folly_build_extNonelibevent2.1.12:
         CONFIG: linux_ppc64le_fmt9folly_build_extNonelibevent2.1.12
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_fmt9folly_build_extjemalloclibevent2.1.10:
+        CONFIG: linux_ppc64le_fmt9folly_build_extjemalloclibevent2.1.10
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_fmt9folly_build_extjemalloclibevent2.1.12:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,38 +8,38 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_fmt10folly_build_extNonelibevent2.1.10:
-        CONFIG: osx_64_fmt10folly_build_extNonelibevent2.1.10
-        UPLOAD_PACKAGES: 'True'
       osx_64_fmt10folly_build_extNonelibevent2.1.12:
         CONFIG: osx_64_fmt10folly_build_extNonelibevent2.1.12
-        UPLOAD_PACKAGES: 'True'
-      osx_64_fmt10folly_build_extjemalloclibevent2.1.10:
-        CONFIG: osx_64_fmt10folly_build_extjemalloclibevent2.1.10
         UPLOAD_PACKAGES: 'True'
       osx_64_fmt10folly_build_extjemalloclibevent2.1.12:
         CONFIG: osx_64_fmt10folly_build_extjemalloclibevent2.1.12
         UPLOAD_PACKAGES: 'True'
+      osx_64_fmt9folly_build_extNonelibevent2.1.10:
+        CONFIG: osx_64_fmt9folly_build_extNonelibevent2.1.10
+        UPLOAD_PACKAGES: 'True'
       osx_64_fmt9folly_build_extNonelibevent2.1.12:
         CONFIG: osx_64_fmt9folly_build_extNonelibevent2.1.12
+        UPLOAD_PACKAGES: 'True'
+      osx_64_fmt9folly_build_extjemalloclibevent2.1.10:
+        CONFIG: osx_64_fmt9folly_build_extjemalloclibevent2.1.10
         UPLOAD_PACKAGES: 'True'
       osx_64_fmt9folly_build_extjemalloclibevent2.1.12:
         CONFIG: osx_64_fmt9folly_build_extjemalloclibevent2.1.12
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_fmt10folly_build_extNonelibevent2.1.10:
-        CONFIG: osx_arm64_fmt10folly_build_extNonelibevent2.1.10
-        UPLOAD_PACKAGES: 'True'
       osx_arm64_fmt10folly_build_extNonelibevent2.1.12:
         CONFIG: osx_arm64_fmt10folly_build_extNonelibevent2.1.12
-        UPLOAD_PACKAGES: 'True'
-      osx_arm64_fmt10folly_build_extjemalloclibevent2.1.10:
-        CONFIG: osx_arm64_fmt10folly_build_extjemalloclibevent2.1.10
         UPLOAD_PACKAGES: 'True'
       osx_arm64_fmt10folly_build_extjemalloclibevent2.1.12:
         CONFIG: osx_arm64_fmt10folly_build_extjemalloclibevent2.1.12
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_fmt9folly_build_extNonelibevent2.1.10:
+        CONFIG: osx_arm64_fmt9folly_build_extNonelibevent2.1.10
+        UPLOAD_PACKAGES: 'True'
       osx_arm64_fmt9folly_build_extNonelibevent2.1.12:
         CONFIG: osx_arm64_fmt9folly_build_extNonelibevent2.1.12
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_fmt9folly_build_extjemalloclibevent2.1.10:
+        CONFIG: osx_arm64_fmt9folly_build_extjemalloclibevent2.1.10
         UPLOAD_PACKAGES: 'True'
       osx_arm64_fmt9folly_build_extjemalloclibevent2.1.12:
         CONFIG: osx_arm64_fmt9folly_build_extjemalloclibevent2.1.12

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,11 +8,11 @@ jobs:
     vmImage: windows-2022
   strategy:
     matrix:
-      win_64_fmt10libevent2.1.10:
-        CONFIG: win_64_fmt10libevent2.1.10
-        UPLOAD_PACKAGES: 'True'
       win_64_fmt10libevent2.1.12:
         CONFIG: win_64_fmt10libevent2.1.12
+        UPLOAD_PACKAGES: 'True'
+      win_64_fmt9libevent2.1.10:
+        CONFIG: win_64_fmt9libevent2.1.10
         UPLOAD_PACKAGES: 'True'
       win_64_fmt9libevent2.1.12:
         CONFIG: win_64_fmt9libevent2.1.12

--- a/.ci_support/linux_64_fmt9folly_build_extNonelibevent2.1.10.yaml
+++ b/.ci_support/linux_64_fmt9folly_build_extNonelibevent2.1.10.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 boost_cpp:
 - 1.78.0
 bzip2:
 - '1'
-cdt_arch:
-- aarch64
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,9 +15,9 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fmt:
-- '10'
+- '9'
 folly_build_ext:
-- jemalloc
+- None
 gflags:
 - '2.2'
 glog:
@@ -38,7 +34,7 @@ pin_run_as_build:
 snappy:
 - '1'
 target_platform:
-- linux-aarch64
+- linux-64
 xz:
 - '5'
 zip_keys:

--- a/.ci_support/linux_64_fmt9folly_build_extjemalloclibevent2.1.10.yaml
+++ b/.ci_support/linux_64_fmt9folly_build_extjemalloclibevent2.1.10.yaml
@@ -1,19 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 boost_cpp:
 - 1.78.0
 bzip2:
 - '1'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '15'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fmt:
-- '10'
+- '9'
 folly_build_ext:
 - jemalloc
 gflags:
@@ -24,8 +26,6 @@ libevent:
 - 2.1.10
 lz4_c:
 - 1.9.3
-macos_machine:
-- arm64-apple-darwin20.0.0
 openssl:
 - '3'
 pin_run_as_build:
@@ -34,7 +34,7 @@ pin_run_as_build:
 snappy:
 - '1'
 target_platform:
-- osx-arm64
+- linux-64
 xz:
 - '5'
 zip_keys:

--- a/.ci_support/linux_aarch64_fmt9folly_build_extNonelibevent2.1.10.yaml
+++ b/.ci_support/linux_aarch64_fmt9folly_build_extNonelibevent2.1.10.yaml
@@ -1,21 +1,25 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 boost_cpp:
 - 1.78.0
 bzip2:
 - '1'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '15'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fmt:
-- '10'
+- '9'
 folly_build_ext:
 - None
 gflags:
@@ -26,8 +30,6 @@ libevent:
 - 2.1.10
 lz4_c:
 - 1.9.3
-macos_machine:
-- x86_64-apple-darwin13.4.0
 openssl:
 - '3'
 pin_run_as_build:
@@ -36,7 +38,7 @@ pin_run_as_build:
 snappy:
 - '1'
 target_platform:
-- osx-64
+- linux-aarch64
 xz:
 - '5'
 zip_keys:

--- a/.ci_support/linux_aarch64_fmt9folly_build_extjemalloclibevent2.1.10.yaml
+++ b/.ci_support/linux_aarch64_fmt9folly_build_extjemalloclibevent2.1.10.yaml
@@ -1,21 +1,27 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 boost_cpp:
 - 1.78.0
 bzip2:
 - '1'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '15'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fmt:
-- '10'
+- '9'
 folly_build_ext:
-- None
+- jemalloc
 gflags:
 - '2.2'
 glog:
@@ -24,8 +30,6 @@ libevent:
 - 2.1.10
 lz4_c:
 - 1.9.3
-macos_machine:
-- arm64-apple-darwin20.0.0
 openssl:
 - '3'
 pin_run_as_build:
@@ -34,7 +38,7 @@ pin_run_as_build:
 snappy:
 - '1'
 target_platform:
-- osx-arm64
+- linux-aarch64
 xz:
 - '5'
 zip_keys:

--- a/.ci_support/linux_ppc64le_fmt9folly_build_extNonelibevent2.1.10.yaml
+++ b/.ci_support/linux_ppc64le_fmt9folly_build_extNonelibevent2.1.10.yaml
@@ -2,14 +2,20 @@ boost_cpp:
 - 1.78.0
 bzip2:
 - '1'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fmt:
-- '10'
+- '9'
 folly_build_ext:
 - None
 gflags:
@@ -28,7 +34,7 @@ pin_run_as_build:
 snappy:
 - '1'
 target_platform:
-- win-64
+- linux-ppc64le
 xz:
 - '5'
 zip_keys:

--- a/.ci_support/linux_ppc64le_fmt9folly_build_extjemalloclibevent2.1.10.yaml
+++ b/.ci_support/linux_ppc64le_fmt9folly_build_extjemalloclibevent2.1.10.yaml
@@ -1,11 +1,7 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 boost_cpp:
 - 1.78.0
 bzip2:
 - '1'
-cdt_arch:
-- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -19,9 +15,9 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fmt:
-- '10'
+- '9'
 folly_build_ext:
-- None
+- jemalloc
 gflags:
 - '2.2'
 glog:
@@ -38,7 +34,7 @@ pin_run_as_build:
 snappy:
 - '1'
 target_platform:
-- linux-aarch64
+- linux-ppc64le
 xz:
 - '5'
 zip_keys:

--- a/.ci_support/osx_64_fmt9folly_build_extNonelibevent2.1.10.yaml
+++ b/.ci_support/osx_64_fmt9folly_build_extNonelibevent2.1.10.yaml
@@ -1,23 +1,23 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 boost_cpp:
 - 1.78.0
 bzip2:
 - '1'
-cdt_name:
-- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '15'
 fmt:
-- '10'
+- '9'
 folly_build_ext:
-- jemalloc
+- None
 gflags:
 - '2.2'
 glog:
@@ -26,6 +26,8 @@ libevent:
 - 2.1.10
 lz4_c:
 - 1.9.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
 openssl:
 - '3'
 pin_run_as_build:
@@ -34,7 +36,7 @@ pin_run_as_build:
 snappy:
 - '1'
 target_platform:
-- linux-64
+- osx-64
 xz:
 - '5'
 zip_keys:

--- a/.ci_support/osx_64_fmt9folly_build_extjemalloclibevent2.1.10.yaml
+++ b/.ci_support/osx_64_fmt9folly_build_extjemalloclibevent2.1.10.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 fmt:
-- '10'
+- '9'
 folly_build_ext:
 - jemalloc
 gflags:

--- a/.ci_support/osx_arm64_fmt9folly_build_extNonelibevent2.1.10.yaml
+++ b/.ci_support/osx_arm64_fmt9folly_build_extNonelibevent2.1.10.yaml
@@ -1,23 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 boost_cpp:
 - 1.78.0
 bzip2:
 - '1'
-cdt_name:
-- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '15'
 fmt:
-- '10'
+- '9'
 folly_build_ext:
-- jemalloc
+- None
 gflags:
 - '2.2'
 glog:
@@ -26,6 +24,8 @@ libevent:
 - 2.1.10
 lz4_c:
 - 1.9.3
+macos_machine:
+- arm64-apple-darwin20.0.0
 openssl:
 - '3'
 pin_run_as_build:
@@ -34,7 +34,7 @@ pin_run_as_build:
 snappy:
 - '1'
 target_platform:
-- linux-ppc64le
+- osx-arm64
 xz:
 - '5'
 zip_keys:

--- a/.ci_support/osx_arm64_fmt9folly_build_extjemalloclibevent2.1.10.yaml
+++ b/.ci_support/osx_arm64_fmt9folly_build_extjemalloclibevent2.1.10.yaml
@@ -1,23 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 boost_cpp:
 - 1.78.0
 bzip2:
 - '1'
-cdt_name:
-- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '15'
 fmt:
-- '10'
+- '9'
 folly_build_ext:
-- None
+- jemalloc
 gflags:
 - '2.2'
 glog:
@@ -26,6 +24,8 @@ libevent:
 - 2.1.10
 lz4_c:
 - 1.9.3
+macos_machine:
+- arm64-apple-darwin20.0.0
 openssl:
 - '3'
 pin_run_as_build:
@@ -34,7 +34,7 @@ pin_run_as_build:
 snappy:
 - '1'
 target_platform:
-- linux-64
+- osx-arm64
 xz:
 - '5'
 zip_keys:

--- a/.ci_support/win_64_fmt9libevent2.1.10.yaml
+++ b/.ci_support/win_64_fmt9libevent2.1.10.yaml
@@ -2,20 +2,14 @@ boost_cpp:
 - 1.78.0
 bzip2:
 - '1'
-cdt_name:
-- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- vs2019
 fmt:
-- '10'
+- '9'
 folly_build_ext:
 - None
 gflags:
@@ -34,7 +28,7 @@ pin_run_as_build:
 snappy:
 - '1'
 target_platform:
-- linux-ppc64le
+- win-64
 xz:
 - '5'
 zip_keys:

--- a/README.md
+++ b/README.md
@@ -39,24 +39,10 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_fmt10folly_build_extNonelibevent2.1.10</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_fmt10folly_build_extNonelibevent2.1.10" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_64_fmt10folly_build_extNonelibevent2.1.12</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_fmt10folly_build_extNonelibevent2.1.12" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_fmt10folly_build_extjemalloclibevent2.1.10</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_fmt10folly_build_extjemalloclibevent2.1.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -67,10 +53,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_fmt9folly_build_extNonelibevent2.1.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_fmt9folly_build_extNonelibevent2.1.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_fmt9folly_build_extNonelibevent2.1.12</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_fmt9folly_build_extNonelibevent2.1.12" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_fmt9folly_build_extjemalloclibevent2.1.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_fmt9folly_build_extjemalloclibevent2.1.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -81,24 +81,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_fmt10folly_build_extNonelibevent2.1.10</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_fmt10folly_build_extNonelibevent2.1.10" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_aarch64_fmt10folly_build_extNonelibevent2.1.12</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_fmt10folly_build_extNonelibevent2.1.12" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_aarch64_fmt10folly_build_extjemalloclibevent2.1.10</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_fmt10folly_build_extjemalloclibevent2.1.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -109,10 +95,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_fmt9folly_build_extNonelibevent2.1.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_fmt9folly_build_extNonelibevent2.1.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_aarch64_fmt9folly_build_extNonelibevent2.1.12</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_fmt9folly_build_extNonelibevent2.1.12" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_fmt9folly_build_extjemalloclibevent2.1.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_fmt9folly_build_extjemalloclibevent2.1.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -123,24 +123,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_fmt10folly_build_extNonelibevent2.1.10</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_fmt10folly_build_extNonelibevent2.1.10" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_ppc64le_fmt10folly_build_extNonelibevent2.1.12</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_fmt10folly_build_extNonelibevent2.1.12" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_ppc64le_fmt10folly_build_extjemalloclibevent2.1.10</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_fmt10folly_build_extjemalloclibevent2.1.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -151,10 +137,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_ppc64le_fmt9folly_build_extNonelibevent2.1.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_fmt9folly_build_extNonelibevent2.1.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_ppc64le_fmt9folly_build_extNonelibevent2.1.12</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_fmt9folly_build_extNonelibevent2.1.12" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_fmt9folly_build_extjemalloclibevent2.1.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_fmt9folly_build_extjemalloclibevent2.1.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -165,24 +165,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_fmt10folly_build_extNonelibevent2.1.10</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_fmt10folly_build_extNonelibevent2.1.10" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>osx_64_fmt10folly_build_extNonelibevent2.1.12</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_fmt10folly_build_extNonelibevent2.1.12" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>osx_64_fmt10folly_build_extjemalloclibevent2.1.10</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_fmt10folly_build_extjemalloclibevent2.1.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -193,10 +179,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_64_fmt9folly_build_extNonelibevent2.1.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_fmt9folly_build_extNonelibevent2.1.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_fmt9folly_build_extNonelibevent2.1.12</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_fmt9folly_build_extNonelibevent2.1.12" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_fmt9folly_build_extjemalloclibevent2.1.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_fmt9folly_build_extjemalloclibevent2.1.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -207,24 +207,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_fmt10folly_build_extNonelibevent2.1.10</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_fmt10folly_build_extNonelibevent2.1.10" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>osx_arm64_fmt10folly_build_extNonelibevent2.1.12</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_fmt10folly_build_extNonelibevent2.1.12" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>osx_arm64_fmt10folly_build_extjemalloclibevent2.1.10</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_fmt10folly_build_extjemalloclibevent2.1.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -235,10 +221,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64_fmt9folly_build_extNonelibevent2.1.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_fmt9folly_build_extNonelibevent2.1.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_arm64_fmt9folly_build_extNonelibevent2.1.12</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_fmt9folly_build_extNonelibevent2.1.12" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_fmt9folly_build_extjemalloclibevent2.1.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_fmt9folly_build_extjemalloclibevent2.1.10" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -249,17 +249,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_fmt10libevent2.1.10</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=win&configuration=win%20win_64_fmt10libevent2.1.10" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>win_64_fmt10libevent2.1.12</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=win&configuration=win%20win_64_fmt10libevent2.1.12" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_fmt9libevent2.1.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13658&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/folly-feedstock?branchName=main&jobName=win&configuration=win%20win_64_fmt9libevent2.1.10" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,12 +6,12 @@ folly_build_ext:
   - None
   - "jemalloc"  # [not win]
 fmt:
-  - "9"
-  - "9"
   - "10"
+  - "9"
+  - "9"
 libevent:
-  - "2.1.10"
   - "2.1.12"
+  - "2.1.10"
   - "2.1.12"
 zip_keys:
   - fmt

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -13,6 +13,15 @@ libevent:
   - "2.1.12"
   - "2.1.10"
   - "2.1.12"
+# `zip_keys` is bugued
+#
+# This specification correctly builds for:
+#
+#     - fmt 9 + libevent 2.1.10
+#     - fmt 9 + libevent 2.1.12
+#     - fmt 10 + libevent 2.1.12
+#
+# See: https://github.com/conda-forge/folly-feedstock/pull/136#discussion_r1305820893
 zip_keys:
   - fmt
   - libevent

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-Use-CMAKE_SYSTEM_PROCESSOR-instead-of-CMAKE_LIBRARY_.patch
 
 build:
-  number: 2
+  number: 3
   string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}{{ build_ext }}
   ignore_run_exports:
     - jemalloc        # [(not osx) and (folly_build_ext is not undefined and folly_build_ext == "jemalloc")]


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Follow-up of #136 due to a bug of `zip_keys`

See: https://github.com/conda-forge/folly-feedstock/pull/136#discussion_r1305820893