### PR TITLE
[ci skip] Perform migrations on 2024.02.19.00

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,7 @@
 bot:
   abi_migration_branches:
   - 2023.09.25.00
+  - 2024.02.19.00
   automerge: true
 build_platform:
   linux_aarch64: linux_64


### PR DESCRIPTION
The `2024.02.19.00` branch has been created to rebuild the eponymous version with newer libraries' versions in the ecosystem (see https://github.com/conda-forge/folly-feedstock/pull/194).

We also need to perform migrations for this branch, hence this proposed change.

cc @h-vetinari