### PR TITLE
[ci skip] Ignore the `2024.02.19.00` branch for migrations

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,6 @@
 bot:
   abi_migration_branches:
   - 2023.09.25.00
-  - 2024.02.19.00
   automerge: true
 build_platform:
   linux_aarch64: linux_64


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

`2024.02.19.00` was created by myself with:
0d139862bb41bf738352ebfae532a4737224e275

But this branch is not used anymore, is is replaced by `2023.09.25.00`.
