### PR TITLE
[2023.09.25.00] Suffix `source` token with `__`

### DIFF
--- a/.ci_support/migrations/lz4_c110.yaml
+++ b/.ci_support/migrations/lz4_c110.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for lz4_c 1.10
-  kind: version
-  migration_number: 1
-lz4_c:
-- '1.10'
-migrator_ts: 1733409380.6728432

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output
+# Pixi's configuration
+.pixi

--- a/recipe/0001-Suffix-source-token-with-__.patch
+++ b/recipe/0001-Suffix-source-token-with-__.patch
@@ -1,4 +1,4 @@
-From e85a6ebe0e477b3db66a4d7f80f25a7dbea38b4c Mon Sep 17 00:00:00 2001
+From 52741e54c9a9a6cf626c3ad86fe28f8bb3edcee1 Mon Sep 17 00:00:00 2001
 From: Julien Jerphanion <git@jjerphan.xyz>
 Date: Fri, 21 Mar 2025 12:23:37 +0100
 Subject: [PATCH] Suffix `source` token with `__`
@@ -14,11 +14,11 @@ error C2065: 'source': undeclared identifier
 
 Signed-off-by: Julien Jerphanion <git@jjerphan.xyz>
 ---
- folly/gen/Base-inl.h | 302 +++++++++++++++++++++----------------------
- 1 file changed, 151 insertions(+), 151 deletions(-)
+ folly/gen/Base-inl.h | 322 +++++++++++++++++++++----------------------
+ 1 file changed, 161 insertions(+), 161 deletions(-)
 
 diff --git a/folly/gen/Base-inl.h b/folly/gen/Base-inl.h
-index bbad83fee..56d00cc6c 100644
+index bbad83fee..1a6484b03 100644
 --- a/folly/gen/Base-inl.h
 +++ b/folly/gen/Base-inl.h
 @@ -202,8 +202,8 @@ class CopiedSource
@@ -653,7 +653,7 @@ index bbad83fee..56d00cc6c 100644
    }
  
    /**
-@@ -1990,7 +1990,7 @@ class FoldLeft : public Operator<FoldLeft<Seed, Fold>> {
+@@ -1990,10 +1990,10 @@ class FoldLeft : public Operator<FoldLeft<Seed, Fold>> {
        : seed_(std::move(seed)), fold_(std::move(fold)) {}
  
    template <class Source, class Value>
@@ -661,16 +661,23 @@ index bbad83fee..56d00cc6c 100644
 +  Seed compose(const GenImpl<Value, Source>& source__) const {
      static_assert(!Source::infinite, "Cannot foldl infinite source");
      Seed accum = seed_;
-     source | [&](Value v) {
-@@ -2015,7 +2015,7 @@ class First : public Operator<First> {
+-    source | [&](Value v) {
++    source__ | [&](Value v) {
+       accum = fold_(std::move(accum), std::forward<Value>(v));
+     };
+     return accum;
+@@ -2015,9 +2015,9 @@ class First : public Operator<First> {
        class Source,
        class Value,
        class StorageType = typename std::decay<Value>::type>
 -  Optional<StorageType> compose(const GenImpl<Value, Source>& source) const {
 +  Optional<StorageType> compose(const GenImpl<Value, Source>& source__) const {
      Optional<StorageType> accum;
-     source | [&](Value v) -> bool {
+-    source | [&](Value v) -> bool {
++    source__ | [&](Value v) -> bool {
        accum = std::forward<Value>(v);
+       return false;
+     };
 @@ -2029,7 +2029,7 @@ class First : public Operator<First> {
   * IsEmpty - a helper class for isEmpty and notEmpty
   *
@@ -689,7 +696,16 @@ index bbad83fee..56d00cc6c 100644
      static_assert(
          !Source::infinite,
          "Cannot call 'all', 'any', 'isEmpty', or 'notEmpty' on "
-@@ -2086,7 +2086,7 @@ class Reduce : public Operator<Reduce<Reducer>> {
+@@ -2054,7 +2054,7 @@ class IsEmpty : public Operator<IsEmpty<emptyResult>> {
+         "false or hang. 'any' or 'notEmpty' will either return true "
+         "or hang.");
+     bool ans = emptyResult;
+-    source | [&](Value /* v */) -> bool {
++    source__ | [&](Value /* v */) -> bool {
+       ans = !emptyResult;
+       return false;
+     };
+@@ -2086,10 +2086,10 @@ class Reduce : public Operator<Reduce<Reducer>> {
        class Source,
        class Value,
        class StorageType = typename std::decay<Value>::type>
@@ -697,7 +713,11 @@ index bbad83fee..56d00cc6c 100644
 +  Optional<StorageType> compose(const GenImpl<Value, Source>& source__) const {
      static_assert(!Source::infinite, "Cannot reduce infinite source");
      Optional<StorageType> accum;
-     source | [&](Value v) {
+-    source | [&](Value v) {
++    source__ | [&](Value v) {
+       if (auto target = accum.get_pointer()) {
+         *target = reducer_(std::move(*target), std::forward<Value>(v));
+       } else {
 @@ -2112,11 +2112,11 @@ class Count : public Operator<Count> {
    Count() = default;
  
@@ -729,7 +749,7 @@ index bbad83fee..56d00cc6c 100644
    }
  };
  
-@@ -2165,7 +2165,7 @@ class Contains : public Operator<Contains<Needle>> {
+@@ -2165,12 +2165,12 @@ class Contains : public Operator<Contains<Needle>> {
        class Source,
        class Value,
        class StorageType = typename std::decay<Value>::type>
@@ -738,7 +758,13 @@ index bbad83fee..56d00cc6c 100644
      static_assert(
          !Source::infinite,
          "Calling contains on an infinite source might cause "
-@@ -2211,7 +2211,7 @@ class Min : public Operator<Min<Selector, Comparer>> {
+         "an infinite loop.");
+-    return !(source | [this](Value value) {
++    return !(source__ | [this](Value value) {
+       return !(needle_ == std::forward<Value>(value));
+     });
+   }
+@@ -2211,14 +2211,14 @@ class Min : public Operator<Min<Selector, Comparer>> {
        class Source,
        class StorageType = typename std::decay<Value>::type,
        class Key = typename std::decay<invoke_result_t<Selector, Value>>::type>
@@ -747,16 +773,28 @@ index bbad83fee..56d00cc6c 100644
      static_assert(
          !Source::infinite,
          "Calling min or max on an infinite source will cause "
-@@ -2250,7 +2250,7 @@ class Append : public Operator<Append<Collection>> {
+         "an infinite loop.");
+     Optional<StorageType> min;
+     Optional<Key> minKey;
+-    source | [&](Value v) {
++    source__ | [&](Value v) {
+       Key key = selector_(asConst(v)); // so that selector_ cannot mutate v
+       if (auto lastKey = minKey.get_pointer()) {
+         if (!comparer_(key, *lastKey)) {
+@@ -2250,9 +2250,9 @@ class Append : public Operator<Append<Collection>> {
    explicit Append(Collection* collection) : collection_(collection) {}
  
    template <class Value, class Source>
 -  Collection& compose(const GenImpl<Value, Source>& source) const {
+-    static_assert(!Source::infinite, "Cannot appendTo with infinite source");
+-    source | [&](Value v) {
 +  Collection& compose(const GenImpl<Value, Source>& source__) const {
-     static_assert(!Source::infinite, "Cannot appendTo with infinite source");
-     source | [&](Value v) {
++    static_assert(!Source::infinite, "Cannot appendTo with infinite source__");
++    source__ | [&](Value v) {
        collection_->insert(collection_->end(), std::forward<Value>(v));
-@@ -2278,7 +2278,7 @@ class Collect : public Operator<Collect<Collection>> {
+     };
+     return *collection_;
+@@ -2278,11 +2278,11 @@ class Collect : public Operator<Collect<Collection>> {
        class Value,
        class Source,
        class StorageType = typename std::decay<Value>::type>
@@ -765,7 +803,12 @@ index bbad83fee..56d00cc6c 100644
      static_assert(
          !Source::infinite, "Cannot convert infinite source to object with as.");
      Collection collection;
-@@ -2318,7 +2318,7 @@ class CollectTemplate : public Operator<CollectTemplate<Container, Allocator>> {
+-    source | [&](Value v) {
++    source__ | [&](Value v) {
+       collection.insert(collection.end(), std::forward<Value>(v));
+     };
+     return collection;
+@@ -2318,11 +2318,11 @@ class CollectTemplate : public Operator<CollectTemplate<Container, Allocator>> {
        class Source,
        class StorageType = typename std::decay<Value>::type,
        class Collection = Container<StorageType, Allocator<StorageType>>>
@@ -774,6 +817,11 @@ index bbad83fee..56d00cc6c 100644
      static_assert(
          !Source::infinite, "Cannot convert infinite source to object with as.");
      Collection collection;
+-    source | [&](Value v) {
++    source__ | [&](Value v) {
+       collection.insert(collection.end(), std::forward<Value>(v));
+     };
+     return collection;
 @@ -2459,8 +2459,8 @@ class ToVirtualGen : public Operator<ToVirtualGen> {
    template <
        class Source,

--- a/recipe/0001-Suffix-source-token-with-__.patch
+++ b/recipe/0001-Suffix-source-token-with-__.patch
@@ -1,0 +1,833 @@
+From e85a6ebe0e477b3db66a4d7f80f25a7dbea38b4c Mon Sep 17 00:00:00 2001
+From: Julien Jerphanion <git@jjerphan.xyz>
+Date: Fri, 21 Mar 2025 12:23:37 +0100
+Subject: [PATCH] Suffix `source` token with `__`
+
+Reason: `source` is a reserved keyword:
+https://learn.microsoft.com/en-us/windows/win32/midl/reserved-keywords
+
+It might lead to compilation issues like:
+```
+C:\Users\runneradmin\micromamba\envs\arcticdb\Library\include\folly\gen\Base-inl.h(395,53):
+error C2065: 'source': undeclared identifier
+```
+
+Signed-off-by: Julien Jerphanion <git@jjerphan.xyz>
+---
+ folly/gen/Base-inl.h | 302 +++++++++++++++++++++----------------------
+ 1 file changed, 151 insertions(+), 151 deletions(-)
+
+diff --git a/folly/gen/Base-inl.h b/folly/gen/Base-inl.h
+index bbad83fee..56d00cc6c 100644
+--- a/folly/gen/Base-inl.h
++++ b/folly/gen/Base-inl.h
+@@ -202,8 +202,8 @@ class CopiedSource
+       : copy_(new Container(std::move(container))) {}
+ 
+   // To enable re-use of cached results.
+-  CopiedSource(const CopiedSource<StorageType, Container>& source)
+-      : copy_(source.copy_) {}
++  CopiedSource(const CopiedSource<StorageType, Container>& source__)
++      : copy_(source__.copy_) {}
+ 
+   template <class Body>
+   void foreach(Body&& body) const {
+@@ -378,8 +378,8 @@ class InfiniteImpl {
+ template <class Value>
+ struct GeneratorBuilder {
+   template <class Source, class Yield = detail::Yield<Value, Source>>
+-  Yield operator+(Source&& source) {
+-    return Yield(std::forward<Source>(source));
++  Yield operator+(Source&& source__) {
++    return Yield(std::forward<Source>(source__));
+   }
+ };
+ 
+@@ -392,7 +392,7 @@ class Yield : public GenImpl<Value, Yield<Value, Source>> {
+   Source source_;
+ 
+  public:
+-  explicit Yield(Source source) : source_(std::move(source)) {}
++  explicit Yield(Source source__) : source_(std::move(source__)) {}
+ 
+   template <class Handler>
+   bool apply(Handler&& handler) const {
+@@ -510,8 +510,8 @@ class Map : public Operator<Map<Predicate>> {
+     Predicate pred_;
+ 
+    public:
+-    explicit Generator(Source source, const Predicate& pred)
+-        : source_(std::move(source)), pred_(pred) {}
++    explicit Generator(Source source__, const Predicate& pred)
++        : source_(std::move(source__)), pred_(pred) {}
+ 
+     template <class Body>
+     void foreach(Body&& body) const {
+@@ -533,8 +533,8 @@ class Map : public Operator<Map<Predicate>> {
+       class Source,
+       class Gen =
+           Generator<typename Source::ValueType, typename Source::SelfType>>
+-  Gen compose(Source source) const {
+-    return Gen(std::move(source.self()), pred_);
++  Gen compose(Source source__) const {
++    return Gen(std::move(source__.self()), pred_);
+   }
+ };
+ 
+@@ -569,8 +569,8 @@ class Filter : public Operator<Filter<Predicate>> {
+     Predicate pred_;
+ 
+    public:
+-    explicit Generator(Source source, const Predicate& pred)
+-        : source_(std::move(source)), pred_(pred) {}
++    explicit Generator(Source source__, const Predicate& pred)
++        : source_(std::move(source__)), pred_(pred) {}
+ 
+     template <class Body>
+     void foreach(Body&& body) const {
+@@ -597,13 +597,13 @@ class Filter : public Operator<Filter<Predicate>> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), pred_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), pred_);
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), pred_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), pred_);
+   }
+ };
+ 
+@@ -630,8 +630,8 @@ class Until : public Operator<Until<Predicate>> {
+     Predicate pred_;
+ 
+    public:
+-    explicit Generator(Source source, const Predicate& pred)
+-        : source_(std::move(source)), pred_(pred) {}
++    explicit Generator(Source source__, const Predicate& pred)
++        : source_(std::move(source__)), pred_(pred) {}
+ 
+     template <class Handler>
+     bool apply(Handler&& handler) const {
+@@ -654,13 +654,13 @@ class Until : public Operator<Until<Predicate>> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), pred_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), pred_);
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), pred_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), pred_);
+   }
+ };
+ 
+@@ -685,8 +685,8 @@ class Take : public Operator<Take> {
+     size_t count_;
+ 
+    public:
+-    explicit Generator(Source source, size_t count)
+-        : source_(std::move(source)), count_(count) {}
++    explicit Generator(Source source__, size_t count)
++        : source_(std::move(source__)), count_(count) {}
+ 
+     template <class Handler>
+     bool apply(Handler&& handler) const {
+@@ -710,13 +710,13 @@ class Take : public Operator<Take> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), count_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), count_);
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), count_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), count_);
+   }
+ };
+ 
+@@ -746,8 +746,8 @@ class Visit : public Operator<Visit<Visitor>> {
+     Visitor visitor_;
+ 
+    public:
+-    explicit Generator(Source source, const Visitor& visitor)
+-        : source_(std::move(source)), visitor_(visitor) {}
++    explicit Generator(Source source__, const Visitor& visitor)
++        : source_(std::move(source__)), visitor_(visitor) {}
+ 
+     template <class Body>
+     void foreach(Body&& body) const {
+@@ -769,13 +769,13 @@ class Visit : public Operator<Visit<Visitor>> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), visitor_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), visitor_);
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), visitor_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), visitor_);
+   }
+ };
+ 
+@@ -803,8 +803,8 @@ class Stride : public Operator<Stride> {
+     size_t stride_;
+ 
+    public:
+-    explicit Generator(Source source, size_t stride)
+-        : source_(std::move(source)), stride_(stride) {}
++    explicit Generator(Source source__, size_t stride)
++        : source_(std::move(source__)), stride_(stride) {}
+ 
+     template <class Handler>
+     bool apply(Handler&& handler) const {
+@@ -834,13 +834,13 @@ class Stride : public Operator<Stride> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), stride_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), stride_);
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), stride_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), stride_);
+   }
+ };
+ 
+@@ -875,8 +875,8 @@ class Sample : public Operator<Sample<Random>> {
+     mutable Rand rng_;
+ 
+    public:
+-    explicit Generator(Source source, size_t count, Random rng)
+-        : source_(std::move(source)), count_(count), rng_(std::move(rng)) {}
++    explicit Generator(Source source__, size_t count, Random rng)
++        : source_(std::move(source__)), count_(count), rng_(std::move(rng)) {}
+ 
+     template <class Handler>
+     bool apply(Handler&& handler) const {
+@@ -920,16 +920,16 @@ class Sample : public Operator<Sample<Random>> {
+       class Source,
+       class Value,
+       class Gen = Generator<Value, Source, Random>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), count_, rng_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), count_, rng_);
+   }
+ 
+   template <
+       class Source,
+       class Value,
+       class Gen = Generator<Value, Source, Random>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), count_, rng_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), count_, rng_);
+   }
+ };
+ 
+@@ -954,8 +954,8 @@ class Skip : public Operator<Skip> {
+     size_t count_;
+ 
+    public:
+-    explicit Generator(Source source, size_t count)
+-        : source_(std::move(source)), count_(count) {}
++    explicit Generator(Source source__, size_t count)
++        : source_(std::move(source__)), count_(count) {}
+ 
+     template <class Body>
+     void foreach(Body&& body) const {
+@@ -993,13 +993,13 @@ class Skip : public Operator<Skip> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), count_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), count_);
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), count_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), count_);
+   }
+ };
+ 
+@@ -1054,8 +1054,8 @@ class Order : public Operator<Order<Selector, Comparer>> {
+     }
+ 
+    public:
+-    Generator(Source source, Selector selector, Comparer comparer)
+-        : source_(std::move(source)),
++    Generator(Source source__, Selector selector, Comparer comparer)
++        : source_(std::move(source__)),
+           selector_(std::move(selector)),
+           comparer_(std::move(comparer)) {}
+ 
+@@ -1097,13 +1097,13 @@ class Order : public Operator<Order<Selector, Comparer>> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), selector_, comparer_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), selector_, comparer_);
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), selector_, comparer_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), selector_, comparer_);
+   }
+ };
+ 
+@@ -1146,8 +1146,8 @@ class GroupBy : public Operator<GroupBy<Selector>> {
+     Selector selector_;
+ 
+    public:
+-    Generator(Source source, Selector selector)
+-        : source_(std::move(source)), selector_(std::move(selector)) {}
++    Generator(Source source__, Selector selector)
++        : source_(std::move(source__)), selector_(std::move(selector)) {}
+ 
+     typedef Group<KeyDecayed, ValueDecayed> GroupType;
+ 
+@@ -1174,13 +1174,13 @@ class GroupBy : public Operator<GroupBy<Selector>> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), selector_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), selector_);
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), selector_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), selector_);
+   }
+ };
+ 
+@@ -1222,8 +1222,8 @@ class GroupByAdjacent : public Operator<GroupByAdjacent<Selector>> {
+     Selector selector_;
+ 
+    public:
+-    Generator(Source source, Selector selector)
+-        : source_(std::move(source)), selector_(std::move(selector)) {}
++    Generator(Source source__, Selector selector)
++        : source_(std::move(source__)), selector_(std::move(selector)) {}
+ 
+     typedef Group<KeyDecayed, ValueDecayed> GroupType;
+ 
+@@ -1275,13 +1275,13 @@ class GroupByAdjacent : public Operator<GroupByAdjacent<Selector>> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), selector_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), selector_);
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), selector_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), selector_);
+   }
+ };
+ 
+@@ -1299,17 +1299,17 @@ class TypeAssertion : public Operator<TypeAssertion<Expected>> {
+  public:
+   TypeAssertion() = default;
+   template <class Source, class Value>
+-  const Source& compose(const GenImpl<Value, Source>& source) const {
++  const Source& compose(const GenImpl<Value, Source>& source__) const {
+     static_assert(
+         std::is_same<Expected, Value>::value, "assert_type() check failed");
+-    return source.self();
++    return source__.self();
+   }
+ 
+   template <class Source, class Value>
+-  Source&& compose(GenImpl<Value, Source>&& source) const {
++  Source&& compose(GenImpl<Value, Source>&& source__) const {
+     static_assert(
+         std::is_same<Expected, Value>::value, "assert_type() check failed");
+-    return std::move(source.self());
++    return std::move(source__.self());
+   }
+ };
+ 
+@@ -1349,8 +1349,8 @@ class Distinct : public Operator<Distinct<Selector>> {
+     typedef typename std::decay<KeyType>::type KeyStorageType;
+ 
+    public:
+-    Generator(Source source, Selector selector)
+-        : source_(std::move(source)), selector_(std::move(selector)) {}
++    Generator(Source source__, Selector selector)
++        : source_(std::move(source__)), selector_(std::move(selector)) {}
+ 
+     template <class Body>
+     void foreach(Body&& body) const {
+@@ -1379,13 +1379,13 @@ class Distinct : public Operator<Distinct<Selector>> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), selector_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), selector_);
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), selector_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), selector_);
+   }
+ };
+ 
+@@ -1404,8 +1404,8 @@ class Composer {
+       class Source,
+       class Ret =
+           decltype(std::declval<Operators>().compose(std::declval<Source>()))>
+-  Ret operator()(Source&& source) const {
+-    return op_.compose(std::forward<Source>(source));
++  Ret operator()(Source&& source__) const {
++    return op_.compose(std::forward<Source>(source__));
+   }
+ };
+ 
+@@ -1444,8 +1444,8 @@ class Batch : public Operator<Batch> {
+     size_t batchSize_;
+ 
+    public:
+-    explicit Generator(Source source, size_t batchSize)
+-        : source_(std::move(source)), batchSize_(batchSize) {}
++    explicit Generator(Source source__, size_t batchSize)
++        : source_(std::move(source__)), batchSize_(batchSize) {}
+ 
+     template <class Handler>
+     bool apply(Handler&& handler) const {
+@@ -1474,13 +1474,13 @@ class Batch : public Operator<Batch> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), batchSize_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), batchSize_);
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), batchSize_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), batchSize_);
+   }
+ };
+ 
+@@ -1517,8 +1517,8 @@ class Window : public Operator<Window> {
+     size_t windowSize_;
+ 
+    public:
+-    explicit Generator(Source source, size_t windowSize)
+-        : source_(std::move(source)), windowSize_(windowSize) {}
++    explicit Generator(Source source__, size_t windowSize)
++        : source_(std::move(source__)), windowSize_(windowSize) {}
+ 
+     template <class Handler>
+     bool apply(Handler&& handler) const {
+@@ -1571,13 +1571,13 @@ class Window : public Operator<Window> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), windowSize_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), windowSize_);
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), windowSize_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), windowSize_);
+   }
+ };
+ 
+@@ -1610,7 +1610,7 @@ class Concat : public Operator<Concat> {
+     Source source_;
+ 
+    public:
+-    explicit Generator(Source source) : source_(std::move(source)) {}
++    explicit Generator(Source source__) : source_(std::move(source__)) {}
+ 
+     template <class Handler>
+     bool apply(Handler&& handler) const {
+@@ -1635,13 +1635,13 @@ class Concat : public Operator<Concat> {
+   };
+ 
+   template <class Value, class Source, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()));
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()));
+   }
+ 
+   template <class Value, class Source, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self());
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self());
+   }
+ };
+ 
+@@ -1670,7 +1670,7 @@ class RangeConcat : public Operator<RangeConcat> {
+     Source source_;
+ 
+    public:
+-    explicit Generator(Source source) : source_(std::move(source)) {}
++    explicit Generator(Source source__) : source_(std::move(source__)) {}
+ 
+     template <class Body>
+     void foreach(Body&& body) const {
+@@ -1699,13 +1699,13 @@ class RangeConcat : public Operator<RangeConcat> {
+   };
+ 
+   template <class Value, class Source, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()));
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()));
+   }
+ 
+   template <class Value, class Source, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self());
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self());
+   }
+ };
+ 
+@@ -1748,8 +1748,8 @@ class GuardImpl : public Operator<GuardImpl<Exception, ErrorHandler>> {
+     ErrorHandler exceptionHandler_;
+ 
+    public:
+-    explicit Generator(Source source, ErrorHandler handler)
+-        : source_(std::move(source)), exceptionHandler_(std::move(handler)) {}
++    explicit Generator(Source source__, ErrorHandler handler)
++        : source_(std::move(source__)), exceptionHandler_(std::move(handler)) {}
+ 
+     template <class Handler>
+     bool apply(Handler&& handler) const {
+@@ -1767,13 +1767,13 @@ class GuardImpl : public Operator<GuardImpl<Exception, ErrorHandler>> {
+   };
+ 
+   template <class Value, class Source, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), exceptionHandler_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), exceptionHandler_);
+   }
+ 
+   template <class Value, class Source, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), exceptionHandler_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), exceptionHandler_);
+   }
+ };
+ 
+@@ -1797,7 +1797,7 @@ class Dereference : public Operator<Dereference> {
+     Source source_;
+ 
+    public:
+-    explicit Generator(Source source) : source_(std::move(source)) {}
++    explicit Generator(Source source__) : source_(std::move(source__)) {}
+ 
+     template <class Body>
+     void foreach(Body&& body) const {
+@@ -1820,13 +1820,13 @@ class Dereference : public Operator<Dereference> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()));
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()));
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self());
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self());
+   }
+ };
+ 
+@@ -1853,7 +1853,7 @@ class Indirect : public Operator<Indirect> {
+         "Cannot use indirect on an rvalue");
+ 
+    public:
+-    explicit Generator(Source source) : source_(std::move(source)) {}
++    explicit Generator(Source source__) : source_(std::move(source__)) {}
+ 
+     template <class Body>
+     void foreach(Body&& body) const {
+@@ -1873,13 +1873,13 @@ class Indirect : public Operator<Indirect> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()));
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()));
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self());
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self());
+   }
+ };
+ 
+@@ -1915,8 +1915,8 @@ class Cycle : public Operator<Cycle<forever>> {
+     off_t limit_;
+ 
+    public:
+-    explicit Generator(Source source, off_t limit)
+-        : source_(std::move(source)), limit_(limit) {}
++    explicit Generator(Source source__, off_t limit)
++        : source_(std::move(source__)), limit_(limit) {}
+ 
+     template <class Handler>
+     bool apply(Handler&& handler) const {
+@@ -1946,13 +1946,13 @@ class Cycle : public Operator<Cycle<forever>> {
+   };
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(GenImpl<Value, Source>&& source) const {
+-    return Gen(std::move(source.self()), limit_);
++  Gen compose(GenImpl<Value, Source>&& source__) const {
++    return Gen(std::move(source__.self()), limit_);
+   }
+ 
+   template <class Source, class Value, class Gen = Generator<Value, Source>>
+-  Gen compose(const GenImpl<Value, Source>& source) const {
+-    return Gen(source.self(), limit_);
++  Gen compose(const GenImpl<Value, Source>& source__) const {
++    return Gen(source__.self(), limit_);
+   }
+ 
+   /**
+@@ -1990,7 +1990,7 @@ class FoldLeft : public Operator<FoldLeft<Seed, Fold>> {
+       : seed_(std::move(seed)), fold_(std::move(fold)) {}
+ 
+   template <class Source, class Value>
+-  Seed compose(const GenImpl<Value, Source>& source) const {
++  Seed compose(const GenImpl<Value, Source>& source__) const {
+     static_assert(!Source::infinite, "Cannot foldl infinite source");
+     Seed accum = seed_;
+     source | [&](Value v) {
+@@ -2015,7 +2015,7 @@ class First : public Operator<First> {
+       class Source,
+       class Value,
+       class StorageType = typename std::decay<Value>::type>
+-  Optional<StorageType> compose(const GenImpl<Value, Source>& source) const {
++  Optional<StorageType> compose(const GenImpl<Value, Source>& source__) const {
+     Optional<StorageType> accum;
+     source | [&](Value v) -> bool {
+       accum = std::forward<Value>(v);
+@@ -2029,7 +2029,7 @@ class First : public Operator<First> {
+  * IsEmpty - a helper class for isEmpty and notEmpty
+  *
+  * Essentially returns 'result' if the source is empty. Note that this cannot be
+- * called on an infinite source, because then there is only one possible return
++ * called on an infinite source__, because then there is only one possible return
+  * value.
+  *
+  *
+@@ -2046,7 +2046,7 @@ class IsEmpty : public Operator<IsEmpty<emptyResult>> {
+   IsEmpty() = default;
+ 
+   template <class Source, class Value>
+-  bool compose(const GenImpl<Value, Source>& source) const {
++  bool compose(const GenImpl<Value, Source>& source__) const {
+     static_assert(
+         !Source::infinite,
+         "Cannot call 'all', 'any', 'isEmpty', or 'notEmpty' on "
+@@ -2086,7 +2086,7 @@ class Reduce : public Operator<Reduce<Reducer>> {
+       class Source,
+       class Value,
+       class StorageType = typename std::decay<Value>::type>
+-  Optional<StorageType> compose(const GenImpl<Value, Source>& source) const {
++  Optional<StorageType> compose(const GenImpl<Value, Source>& source__) const {
+     static_assert(!Source::infinite, "Cannot reduce infinite source");
+     Optional<StorageType> accum;
+     source | [&](Value v) {
+@@ -2112,11 +2112,11 @@ class Count : public Operator<Count> {
+   Count() = default;
+ 
+   template <class Source, class Value>
+-  size_t compose(const GenImpl<Value, Source>& source) const {
++  size_t compose(const GenImpl<Value, Source>& source__) const {
+     static_assert(!Source::infinite, "Cannot count infinite source");
+     return foldl(
+                size_t(0), [](size_t accum, Value /* v */) { return accum + 1; })
+-        .compose(source);
++        .compose(source__);
+   }
+ };
+ 
+@@ -2135,14 +2135,14 @@ class Sum : public Operator<Sum> {
+       class Source,
+       class Value,
+       class StorageType = typename std::decay<Value>::type>
+-  StorageType compose(const GenImpl<Value, Source>& source) const {
++  StorageType compose(const GenImpl<Value, Source>& source__) const {
+     static_assert(!Source::infinite, "Cannot sum infinite source");
+     return foldl(
+                StorageType(0),
+                [](StorageType&& accum, Value v) {
+                  return std::move(accum) + std::forward<Value>(v);
+                })
+-        .compose(source);
++        .compose(source__);
+   }
+ };
+ 
+@@ -2165,7 +2165,7 @@ class Contains : public Operator<Contains<Needle>> {
+       class Source,
+       class Value,
+       class StorageType = typename std::decay<Value>::type>
+-  bool compose(const GenImpl<Value, Source>& source) const {
++  bool compose(const GenImpl<Value, Source>& source__) const {
+     static_assert(
+         !Source::infinite,
+         "Calling contains on an infinite source might cause "
+@@ -2211,7 +2211,7 @@ class Min : public Operator<Min<Selector, Comparer>> {
+       class Source,
+       class StorageType = typename std::decay<Value>::type,
+       class Key = typename std::decay<invoke_result_t<Selector, Value>>::type>
+-  Optional<StorageType> compose(const GenImpl<Value, Source>& source) const {
++  Optional<StorageType> compose(const GenImpl<Value, Source>& source__) const {
+     static_assert(
+         !Source::infinite,
+         "Calling min or max on an infinite source will cause "
+@@ -2250,7 +2250,7 @@ class Append : public Operator<Append<Collection>> {
+   explicit Append(Collection* collection) : collection_(collection) {}
+ 
+   template <class Value, class Source>
+-  Collection& compose(const GenImpl<Value, Source>& source) const {
++  Collection& compose(const GenImpl<Value, Source>& source__) const {
+     static_assert(!Source::infinite, "Cannot appendTo with infinite source");
+     source | [&](Value v) {
+       collection_->insert(collection_->end(), std::forward<Value>(v));
+@@ -2278,7 +2278,7 @@ class Collect : public Operator<Collect<Collection>> {
+       class Value,
+       class Source,
+       class StorageType = typename std::decay<Value>::type>
+-  Collection compose(const GenImpl<Value, Source>& source) const {
++  Collection compose(const GenImpl<Value, Source>& source__) const {
+     static_assert(
+         !Source::infinite, "Cannot convert infinite source to object with as.");
+     Collection collection;
+@@ -2318,7 +2318,7 @@ class CollectTemplate : public Operator<CollectTemplate<Container, Allocator>> {
+       class Source,
+       class StorageType = typename std::decay<Value>::type,
+       class Collection = Container<StorageType, Allocator<StorageType>>>
+-  Collection compose(const GenImpl<Value, Source>& source) const {
++  Collection compose(const GenImpl<Value, Source>& source__) const {
+     static_assert(
+         !Source::infinite, "Cannot convert infinite source to object with as.");
+     Collection collection;
+@@ -2459,8 +2459,8 @@ class ToVirtualGen : public Operator<ToVirtualGen> {
+   template <
+       class Source,
+       class Generator = VirtualGenMoveOnly<typename Source::ValueType>>
+-  Generator compose(Source source) const {
+-    return Generator(std::move(source.self()));
++  Generator compose(Source source__) const {
++    return Generator(std::move(source__.self()));
+   }
+ };
+ 
+@@ -2647,21 +2647,21 @@ class VirtualGen : public VirtualGenBase<Value, VirtualGen<Value>> {
+ 
+  public:
+   VirtualGen() = default;
+-  VirtualGen(VirtualGen&& source) = default;
+-  VirtualGen& operator=(VirtualGen&& source) = default;
++  VirtualGen(VirtualGen&& source__) = default;
++  VirtualGen& operator=(VirtualGen&& source__) = default;
+ 
+   template <class Source>
+-  /* implicit */ VirtualGen(Source source) {
++  /* implicit */ VirtualGen(Source source__) {
+     this->wrapper_ =
+-        std::make_unique<CloneableWrapperImpl<Source>>(std::move(source));
++        std::make_unique<CloneableWrapperImpl<Source>>(std::move(source__));
+   }
+ 
+-  VirtualGen(const VirtualGen& source) {
+-    this->wrapper_ = source.wrapper_->clone();
++  VirtualGen(const VirtualGen& source__) {
++    this->wrapper_ = source__.wrapper_->clone();
+   }
+ 
+-  VirtualGen& operator=(const VirtualGen& source) {
+-    return *this = VirtualGen(source);
++  VirtualGen& operator=(const VirtualGen& source__) {
++    return *this = VirtualGen(source__);
+   }
+ };
+ 
+@@ -2674,10 +2674,10 @@ class VirtualGenMoveOnly
+   VirtualGenMoveOnly& operator=(VirtualGenMoveOnly&&) = default;
+ 
+   template <class Source>
+-  /* implicit */ VirtualGenMoveOnly(Source source) {
++  /* implicit */ VirtualGenMoveOnly(Source source__) {
+     this->wrapper_ = std::make_unique<
+         typename VirtualGenBase<Value, VirtualGenMoveOnly<Value>>::
+-            template WrapperImpl<Source>>(std::move(source));
++            template WrapperImpl<Source>>(std::move(source__));
+   }
+ };
+ 
+-- 
+2.48.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,9 +18,10 @@ source:
     - 0001-tweak-Range-and-fix-for-fmt-11.patch
     - 0001-Remove-package-config-file-generation.patch  # [win]
     - 0001-Add-utf-8-support.patch  # [win]
+    - 0001-Suffix-source-token-with-__.patch  # [win]
 
 build:
-  number: 11
+  number: 12
   string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}{{ build_ext }}
   ignore_run_exports:
     - jemalloc        # [(not osx) and (folly_build_ext is not undefined and folly_build_ext == "jemalloc")]


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


**Motivations**:

Error messages when building ArcticDB for Windows (see [those logs](https://github.com/man-group/ArcticDB/actions/runs/13989973262/job/39171545587)); an extract:

```
        6>C:\Users\runneradmin\micromamba\envs\arcticdb\Library\include\folly\gen\Base-inl.h(395,53): error C2065: 'source': undeclared identifier [D:\a\ArcticDB\ArcticDB\cpp\out\windows-cl-conda-release-build\arcticdb\arcticdb_core_object.vcxproj]
           (compiling source file '../../../arcticdb/entity/metrics.cpp')
               C:\Users\runneradmin\micromamba\envs\arcticdb\Library\include\folly\gen\Base-inl.h(395,53):
               the template instantiation context (the oldest one first) is
                   C:\Users\runneradmin\micromamba\envs\arcticdb\Library\include\folly\gen\Base-inl.h(391,7):
                   while compiling class template 'folly::gen::detail::Yield'

       6>C:\Users\runneradmin\micromamba\envs\arcticdb\Library\include\folly\gen\Base-inl.h(395,33): error C2178: 'folly::gen::detail::Yield<Value,Source>::<alignment member>' cannot be declared with 'explicit' specifier [D:\a\ArcticDB\ArcticDB\cpp\out\windows-cl-conda-release-build\arcticdb\arcticdb_core_object.vcxproj]
           (compiling source file '../../../arcticdb/entity/metrics.cpp')

       6>C:\Users\runneradmin\micromamba\envs\arcticdb\Library\include\folly\gen\Base-inl.h(395,62): error C7583: an unnamed bit-field cannot have a default member initializer [D:\a\ArcticDB\ArcticDB\cpp\out\windows-cl-conda-release-build\arcticdb\arcticdb_core_object.vcxproj]
           (compiling source file '../../../arcticdb/entity/metrics.cpp')

       6>C:\Users\runneradmin\micromamba\envs\arcticdb\Library\include\folly\gen\Base-inl.h(417,1): error C1903: unable to recover from previous error(s); stopping compilation [D:\a\ArcticDB\ArcticDB\cpp\out\windows-cl-conda-release-build\arcticdb\arcticdb_core_object.vcxproj]
           (compiling source file '../../../arcticdb/entity/metrics.cpp')
```

</details>

@conda-forge-admin, please rerender


